### PR TITLE
Updated Size Value in API Request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hltb-for-deck",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "A plugin to show you game lengths according to How Long To Beat",
     "scripts": {
         "build": "rollup -c",

--- a/src/hooks/useHltb.ts
+++ b/src/hooks/useHltb.ts
@@ -31,7 +31,7 @@ const useHltb = (appId: number, game: string, serverApi: ServerAPI) => {
         searchType: 'games',
         searchTerms: game.split(' '),
         searchPage: 1,
-        size: 50,
+        size: 20,
         searchOptions: {
             games: {
                 userId: 0,


### PR DESCRIPTION
Changed the size parameter in the request from '50' to '20' to get results from the site once again (the current '50' value just results in a 200 response with an empty set). Also, the version number has been changed to 1.4.3