### PR TITLE
fix: update API to use appId again

### DIFF
--- a/src/components/GameStats/GameStats.tsx
+++ b/src/components/GameStats/GameStats.tsx
@@ -15,6 +15,7 @@ interface GameStatsProps {
     game: string;
     appId: number;
     id: string;
+    isSteamGame: boolean;
 }
 
 function findTopCapsuleParent(ref: HTMLDivElement | null): Element | null {
@@ -46,7 +47,7 @@ function findTopCapsuleParent(ref: HTMLDivElement | null): Element | null {
     return topCapsule;
 }
 
-export const GameStats = ({ game, appId, id }: GameStatsProps) => {
+export const GameStats = ({ game, appId, id, isSteamGame }: GameStatsProps) => {
     // There will be no mutation when the page is loaded (either from exiting the game
     // or just newly opening the page), therefore it's not "launching" by default.
     const [gameLaunching, setGameLaunching] = useState<boolean>(false);
@@ -108,7 +109,7 @@ export const GameStats = ({ game, appId, id }: GameStatsProps) => {
         allStylesStat,
         gameId,
         showStats,
-    } = useHltb(appId, game);
+    } = useHltb(appId, game, isSteamGame);
     const { showMain, showMainPlus, showComplete, showAllStyles } =
         useStatPreferences();
     const hltbStyle = useStyle();

--- a/src/hooks/GameInfoData.ts
+++ b/src/hooks/GameInfoData.ts
@@ -1,59 +1,41 @@
-export type SearchResults = {
-    category: string;
-    color: string;
-    count: number;
-    data: GameStatsData[];
-    pageCurrent: number;
-    pageSize: number;
-    pageTotal: number;
-    title: string;
-};
+export interface SearchResults {
+    data: Array<{
+        game_id: number;
+        game_name: string;
+        comp_all_count: number;
+    }>;
+}
 
-export type HLTBStats = {
+export interface GamePageData {
+    pageProps: {
+        game: {
+            data: {
+                game: GameData[];
+            };
+        };
+    };
+}
+
+export interface GameData {
+    comp_main: number;
+    comp_plus: number;
+    comp_100: number;
+    comp_all: number;
+    game_id: number;
+    profile_steam: number;
+}
+
+export interface HLTBGameStats {
     mainStat: string;
     mainPlusStat: string;
     completeStat: string;
     allStylesStat: string;
     lastUpdatedAt: Date;
+    gameId: number;
+}
+
+export interface HLTBStats extends Omit<HLTBGameStats, 'gameId'> {
     gameId?: number;
     showStats: boolean;
-};
-
-export type GameStatsData = {
-    count: number;
-    game_id: number;
-    game_name: string;
-    game_name_date: number;
-    game_alias: string;
-    game_type: string;
-    game_image: string;
-    comp_lvl_combine: number;
-    comp_lvl_sp: number;
-    comp_lvl_co: number;
-    comp_lvl_mp: number;
-    comp_lvl_spd: number;
-    comp_main: number;
-    comp_plus: number;
-    comp_100: number;
-    comp_all: number;
-    comp_main_count: number;
-    comp_plus_count: number;
-    comp_100_count: number;
-    comp_all_count: number;
-    invested_co: number;
-    invested_mp: number;
-    invested_co_count: number;
-    invested_mp_count: number;
-    count_comp: number;
-    count_speedrun: number;
-    count_backlog: number;
-    count_review: number;
-    review_score: number;
-    count_playing: number;
-    count_retired: number;
-    profile_dev: string;
-    profile_popular: number;
-    profile_steam: number;
-    profile_platform: string;
-    release_world: number;
-};
+    version?: number;
+}

--- a/src/hooks/HltbApi.ts
+++ b/src/hooks/HltbApi.ts
@@ -1,0 +1,386 @@
+import { fetchNoCors } from '@decky/api';
+import {
+    GameData,
+    GamePageData,
+    HLTBGameStats,
+    SearchResults,
+} from './GameInfoData';
+import { normalize } from '../utils';
+import { get } from 'fast-levenshtein';
+
+// NOTE: Close reproduction of https://github.com/ScrappyCocco/HowLongToBeat-PythonAPI/pull/26
+const SearchKey = Symbol('Search Key');
+async function fetchSearchKey() {
+    try {
+        const url = 'https://howlongtobeat.com';
+        const response = await fetchNoCors(url);
+
+        if (response.status === 200) {
+            const html = await response.text();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            const scripts = doc.querySelectorAll('script');
+
+            for (const script of scripts) {
+                if (script.src.includes('_app-')) {
+                    const scriptUrl = url + new URL(script.src).pathname;
+                    const scriptResponse = await fetchNoCors(scriptUrl);
+
+                    if (scriptResponse.status === 200) {
+                        const scriptText = await scriptResponse.text();
+                        const pattern =
+                            /"\/api\/search\/".concat\("([a-zA-Z0-9]+)"\)/;
+                        const matches = scriptText.match(pattern);
+
+                        if (matches && matches[1]) {
+                            return matches[1];
+                        }
+                    }
+                }
+            }
+
+            console.error('HLTB - failed to get API key!');
+        } else {
+            console.error('HLTB', response);
+        }
+    } catch (error) {
+        console.error(error);
+    }
+
+    return null;
+}
+
+const NextJsKey = Symbol('NextJs Key');
+async function fetchNextJsKey() {
+    try {
+        const url = 'https://howlongtobeat.com';
+        const response = await fetchNoCors(url);
+
+        if (response.status === 200) {
+            const html = await response.text();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            const scripts = doc.querySelectorAll('script');
+
+            for (const script of scripts) {
+                if (
+                    script.src.includes('_ssgManifest.js') ||
+                    script.src.includes('_buildManifest.js')
+                ) {
+                    const pattern =
+                        /\/_next\/static\/(.+)\/(?:_ssgManifest|_buildManifest)\.js/;
+                    const matches = script.src.match(pattern);
+
+                    if (matches && matches[1]) {
+                        return matches[1];
+                    }
+                }
+            }
+
+            console.error('HLTB - failed to get NextJs key!');
+        } else {
+            console.error('HLTB', response);
+        }
+    } catch (error) {
+        console.error(error);
+    }
+
+    return null;
+}
+
+const keyCache = new Map<
+    symbol,
+    { key: string | null; keyFetch: () => Promise<string | null> }
+>([
+    [SearchKey, { key: null, keyFetch: fetchSearchKey }],
+    [NextJsKey, { key: null, keyFetch: fetchNextJsKey }],
+]);
+async function fetchWithKey(
+    keyName: symbol,
+    callback: (key: string) => Promise<Response>
+) {
+    let cache = keyCache.get(keyName);
+    if (!cache) {
+        console.error('HLTB - failed to get cache item for', keyName);
+        return null;
+    }
+
+    cache.key = cache.key || (await cache.keyFetch());
+    if (cache.key === null) {
+        // error already logged
+        return null;
+    }
+
+    const results = await callback(cache.key);
+    if (results.status === 200) {
+        return results;
+    }
+
+    // Key might have expired, fetch a new one and try again
+    cache.key = await cache.keyFetch();
+    if (cache.key === null) {
+        // error already logged
+        return null;
+    }
+
+    // Whatever the response is, we propagate it to be logged
+    return await callback(cache.key);
+}
+
+async function fetchSearchResultsWithKey(gameName: string, apiKey: string) {
+    const data = {
+        searchType: 'games',
+        searchTerms: gameName.split(' '),
+        searchPage: 1,
+        size: 20,
+        searchOptions: {
+            games: {
+                userId: 0,
+                platform: '',
+                sortCategory: 'name',
+                rangeCategory: 'main',
+                rangeTime: { min: 0, max: 0 },
+                gameplay: { perspective: '', flow: '', genre: '' },
+                modifier: 'hide_dlc',
+            },
+            users: {},
+            filter: '',
+            sort: 0,
+            randomizer: 0,
+        },
+    };
+
+    return fetchNoCors(`https://howlongtobeat.com/api/search/${apiKey}`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://howlongtobeat.com',
+            Referer: 'https://howlongtobeat.com/',
+            Authority: 'howlongtobeat.com',
+            'User-Agent':
+                'Chrome: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36',
+        },
+        body: JSON.stringify(data),
+    });
+}
+
+async function fetchSearchResults(appName: string) {
+    const response = await fetchWithKey(SearchKey, (key) =>
+        fetchSearchResultsWithKey(appName, key)
+    );
+    if (!response) {
+        // Error already logged
+        return null;
+    }
+
+    if (response.status !== 200) {
+        console.error('HLTB', response);
+        return null;
+    }
+
+    const results: SearchResults = await response.json();
+    const logInvalidDataAndReturn = () => {
+        console.error(
+            'HLTB - unexpected JSON data for search results',
+            results
+        );
+        return null;
+    };
+
+    if (!Array.isArray(results?.data)) {
+        return logInvalidDataAndReturn();
+    }
+
+    for (const item of results.data) {
+        if (typeof item?.game_id !== 'number') {
+            return logInvalidDataAndReturn();
+        }
+
+        if (typeof item?.game_name !== 'string') {
+            return logInvalidDataAndReturn();
+        }
+
+        if (typeof item?.comp_all_count !== 'number') {
+            return logInvalidDataAndReturn();
+        }
+
+        item.game_name = normalize(item.game_name);
+    }
+
+    return results;
+}
+
+async function fetchGamePageDataWithKey(gameId: number, apiKey: string) {
+    return fetchNoCors(
+        `https://howlongtobeat.com/_next/data/${apiKey}/game/${gameId}.json`,
+        {
+            method: 'GET',
+        }
+    );
+}
+
+async function fetchGameData(gameId: number) {
+    const response = await fetchWithKey(NextJsKey, (key) =>
+        fetchGamePageDataWithKey(gameId, key)
+    );
+    if (!response) {
+        // Error already logged
+        return null;
+    }
+
+    if (response.status !== 200) {
+        console.error('HLTB', response);
+        return null;
+    }
+
+    const results: GamePageData = await response.json();
+    const logInvalidDataAndReturn = () => {
+        console.error('HLTB - unexpected JSON data for game page', results);
+        return null;
+    };
+
+    if (!Array.isArray(results?.pageProps?.game?.data?.game)) {
+        return logInvalidDataAndReturn();
+    }
+
+    const gameDataList = results.pageProps.game.data.game;
+    if (gameDataList.length !== 1) {
+        return logInvalidDataAndReturn();
+    }
+
+    const gameData = gameDataList[0];
+
+    if (typeof gameData?.comp_main !== 'number') {
+        return logInvalidDataAndReturn();
+    }
+
+    if (typeof gameData?.comp_plus !== 'number') {
+        return logInvalidDataAndReturn();
+    }
+
+    if (typeof gameData?.comp_100 !== 'number') {
+        return logInvalidDataAndReturn();
+    }
+
+    if (typeof gameData?.comp_all !== 'number') {
+        return logInvalidDataAndReturn();
+    }
+
+    if (typeof gameData?.game_id !== 'number') {
+        return logInvalidDataAndReturn();
+    }
+
+    if (typeof gameData?.profile_steam !== 'number') {
+        return logInvalidDataAndReturn();
+    }
+
+    return gameData;
+}
+
+async function fetchMostCompatibleGameData(
+    appName: string,
+    appId?: number,
+    hltbGameId?: number
+) {
+    if (typeof hltbGameId === 'number') {
+        return await fetchGameData(hltbGameId);
+    }
+
+    const searchResults = await fetchSearchResults(appName);
+    if (searchResults === null) {
+        // Error already logged
+        return null;
+    }
+
+    const gameDataCache = new Map<number, GameData>();
+    const getGameData = async (gameId: number) => {
+        return gameDataCache.get(gameId) ?? (await fetchGameData(gameId));
+    };
+
+    // Search by appId first
+    if (typeof appId === 'number') {
+        for (const item of searchResults.data) {
+            const gameData = await fetchGameData(item.game_id);
+            if (gameData === null) {
+                // Error already logged (we should return here, not continue)
+                return null;
+            }
+
+            if (gameData.profile_steam === appId) {
+                return gameData;
+            }
+
+            gameDataCache.set(item.game_id, gameData);
+        }
+    }
+
+    // Search by app name if not found by appId
+    for (const item of searchResults.data) {
+        if (item.game_name === appName) {
+            return getGameData(item.game_id);
+        }
+    }
+
+    // Couldn't find anything, find a closest match
+    if (searchResults.data.length > 0) {
+        const possibleChoices = searchResults.data
+            .map((item) => {
+                return {
+                    minEditDistance: get(appName, item.game_name, {
+                        useCollator: true,
+                    }),
+                    item,
+                };
+            })
+            .sort((a, b) => {
+                if (a.minEditDistance === b.minEditDistance) {
+                    return b.item.comp_all_count - a.item.comp_all_count;
+                } else {
+                    return a.minEditDistance - b.minEditDistance;
+                }
+            });
+        return getGameData(possibleChoices[0].item.game_id);
+    }
+
+    return null;
+}
+
+export async function fetchHltbGameStats(
+    appName: string,
+    appId?: number,
+    hltbGameId?: number
+): Promise<HLTBGameStats | null> {
+    try {
+        const gameData = await fetchMostCompatibleGameData(
+            appName,
+            appId,
+            hltbGameId
+        );
+        if (gameData) {
+            return {
+                mainStat:
+                    gameData.comp_main > 0
+                        ? (gameData.comp_main / 60 / 60).toFixed(1)
+                        : '--',
+                mainPlusStat:
+                    gameData.comp_plus > 0
+                        ? (gameData.comp_plus / 60 / 60).toFixed(1)
+                        : '--',
+                completeStat:
+                    gameData.comp_100 > 0
+                        ? (gameData.comp_100 / 60 / 60).toFixed(1)
+                        : '--',
+                allStylesStat:
+                    gameData.comp_all > 0
+                        ? (gameData.comp_all / 60 / 60).toFixed(1)
+                        : '--',
+                gameId: gameData.game_id,
+                lastUpdatedAt: new Date(),
+            };
+        }
+    } catch (error) {
+        console.error('HLTB', error);
+    }
+
+    return null;
+}

--- a/src/hooks/useHltb.ts
+++ b/src/hooks/useHltb.ts
@@ -1,101 +1,31 @@
-import { fetchNoCors } from '@decky/api';
-import { get } from 'fast-levenshtein';
 import { useState, useEffect } from 'react';
-import { normalize } from '../utils';
-import { GameStatsData, HLTBStats, SearchResults } from './GameInfoData';
+import { HLTBStats } from './GameInfoData';
 import { getCache, updateCache } from './Cache';
+import { fetchHltbGameStats } from './HltbApi';
 
-// update cache after 12 hours
-function needCacheUpdate(lastUpdatedAt: Date) {
+// This number should be incremented whenever it is needed
+// to forcefully invalidate cache, so that the user doesn't
+// have to manually clear it.
+const statsVersion = 1;
+function hasVersionChanged(cache: HLTBStats) {
+    return cache.version !== statsVersion;
+}
+
+function getCachedGameId(cache: HLTBStats | null) {
+    return !cache || hasVersionChanged(cache) ? undefined : cache?.gameId;
+}
+
+// update cache after 12 hours or if the version number is different
+function needCacheUpdate(cache: HLTBStats) {
     const now = new Date();
-    const durationMs = Math.abs(lastUpdatedAt.getTime() - now.getTime());
+    const durationMs = Math.abs(cache.lastUpdatedAt.getTime() - now.getTime());
 
     const hoursBetweenDates = durationMs / (60 * 60 * 1000);
-    return hoursBetweenDates > 12;
-}
-
-// NOTE: Close reproduction of https://github.com/ScrappyCocco/HowLongToBeat-PythonAPI/pull/26
-async function fetchApiKey() {
-    try {
-        const url = 'https://howlongtobeat.com';
-        const response = await fetchNoCors(url);
-
-        if (response.status === 200) {
-            const html = await response.text();
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(html, 'text/html');
-            const scripts = doc.querySelectorAll('script');
-
-            for (const script of scripts) {
-                if (script.src.includes('_app-')) {
-                    const scriptUrl = url + new URL(script.src).pathname;
-                    const scriptResponse = await fetchNoCors(scriptUrl);
-
-                    if (scriptResponse.status === 200) {
-                        const scriptText = await scriptResponse.text();
-                        const pattern =
-                            /"\/api\/search\/".concat\("([a-zA-Z0-9]+)"\)/;
-                        const matches = scriptText.match(pattern);
-
-                        if (matches && matches[1]) {
-                            return matches[1];
-                        }
-                    }
-                }
-            }
-
-            console.error('HLTB - failed to get API key!');
-        } else {
-            console.error(`HLTB - ${response}`);
-        }
-    } catch (error) {
-        console.error(error);
-    }
-
-    return null;
-}
-
-async function fetchSearchResultsWithKey(data: object, apiKey: string) {
-    return fetchNoCors(`https://howlongtobeat.com/api/search/${apiKey}`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            Origin: 'https://howlongtobeat.com',
-            Referer: 'https://howlongtobeat.com/',
-            Authority: 'howlongtobeat.com',
-            'User-Agent':
-                'Chrome: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36',
-        },
-        body: JSON.stringify(data),
-    });
-}
-
-let CachedApiKey: string | null = null;
-async function fetchSearchResults(data: object) {
-    CachedApiKey = CachedApiKey || (await fetchApiKey());
-    if (CachedApiKey === null) {
-        // error already logged
-        return null;
-    }
-
-    let results = await fetchSearchResultsWithKey(data, CachedApiKey);
-    if (results.status === 200) {
-        return results;
-    }
-
-    // key might have expired, fetch a new one and try again
-    CachedApiKey = await fetchApiKey();
-    if (CachedApiKey === null) {
-        // error already logged
-        return null;
-    }
-
-    // Whatever the response is, we propagate it to be logged
-    return await fetchSearchResultsWithKey(data, CachedApiKey);
+    return hoursBetweenDates > 12 || hasVersionChanged(cache);
 }
 
 // Hook to get data from HLTB
-function useHltb(appId: number, game: string) {
+function useHltb(appId: number, appName: string, isSteamGame: boolean) {
     const [stats, setStats] = useState<HLTBStats>({
         mainStat: '--',
         mainPlusStat: '--',
@@ -104,143 +34,39 @@ function useHltb(appId: number, game: string) {
         gameId: undefined,
         lastUpdatedAt: new Date(),
         showStats: true,
+        version: statsVersion,
     });
-    const data = {
-        searchType: 'games',
-        searchTerms: game.split(' '),
-        searchPage: 1,
-        size: 20,
-        searchOptions: {
-            games: {
-                userId: 0,
-                platform: '',
-                sortCategory: 'name',
-                rangeCategory: 'main',
-                rangeTime: { min: 0, max: 0 },
-                gameplay: { perspective: '', flow: '', genre: '' },
-                modifier: 'hide_dlc',
-            },
-            users: {},
-            filter: '',
-            sort: 0,
-            randomizer: 0,
-        },
-    };
 
     useEffect(() => {
         const getData = async () => {
             const cache = await getCache<HLTBStats>(`${appId}`);
-            if (cache && !needCacheUpdate(cache.lastUpdatedAt)) {
+            if (cache && !needCacheUpdate(cache)) {
                 setStats(cache);
             } else {
-                console.log(`get HLTB data for ${appId} and ${game}`);
-                try {
-                    const result = await fetchSearchResults(data);
-                    if (!result) {
-                        // failed to get api key, error already logged
-                        return;
-                    }
-
-                    if (result.status === 200) {
-                        const results: SearchResults = await result.json();
-                        results.data.forEach((game) => {
-                            game.game_name = normalize(game.game_name);
-                        });
-                        // Search by appId first
-                        let gameStats: GameStatsData | undefined =
-                            results.data.find(
-                                (elem) => elem.profile_steam === appId
-                            );
-                        // Search by game name if not found by appId
-                        if (gameStats === undefined)
-                            gameStats = results.data.find(
-                                (elem) => elem.game_name === game
-                            );
-                        // Couldn't find anything, find a close match
-                        if (
-                            gameStats === undefined &&
-                            results.data.length > 0
-                        ) {
-                            const possibleChoices = results.data
-                                .map((gameStat) => {
-                                    return {
-                                        minEditDistance: get(
-                                            game,
-                                            gameStat.game_name,
-                                            { useCollator: true }
-                                        ),
-                                        gameStat,
-                                    };
-                                })
-                                .sort((a, b) => {
-                                    if (
-                                        a.minEditDistance === b.minEditDistance
-                                    ) {
-                                        return (
-                                            b.gameStat.comp_all_count -
-                                            a.gameStat.comp_all_count
-                                        );
-                                    } else {
-                                        return (
-                                            a.minEditDistance -
-                                            b.minEditDistance
-                                        );
-                                    }
-                                });
-                            gameStats = possibleChoices[0].gameStat;
-                        }
-                        let newStats = stats;
-                        if (gameStats) {
-                            newStats = {
-                                mainStat:
-                                    gameStats.comp_main > 0
-                                        ? (
-                                              gameStats.comp_main /
-                                              60 /
-                                              60
-                                          ).toFixed(1)
-                                        : '--',
-                                mainPlusStat:
-                                    gameStats.comp_plus > 0
-                                        ? (
-                                              gameStats.comp_plus /
-                                              60 /
-                                              60
-                                          ).toFixed(1)
-                                        : '--',
-                                completeStat:
-                                    gameStats.comp_100 > 0
-                                        ? (
-                                              gameStats.comp_100 /
-                                              60 /
-                                              60
-                                          ).toFixed(1)
-                                        : '--',
-                                allStylesStat:
-                                    gameStats.comp_all > 0
-                                        ? (
-                                              gameStats.comp_all /
-                                              60 /
-                                              60
-                                          ).toFixed(1)
-                                        : '--',
-                                gameId: gameStats.game_id,
-                                lastUpdatedAt: new Date(),
-                                showStats: cache?.showStats ?? true,
-                            };
-                        }
-                        setStats(newStats);
-                        updateCache(`${appId}`, newStats);
-                    } else {
-                        console.error(`HLTB - ${result}`);
-                    }
-                } catch (error) {
-                    console.error(error);
+                console.log(`Getting HLTB data for ${appId} and "${appName}".`);
+                const hltbGameStats = await fetchHltbGameStats(
+                    appName,
+                    isSteamGame ? appId : undefined,
+                    getCachedGameId(cache)
+                );
+                if (hltbGameStats) {
+                    const newStats = {
+                        ...hltbGameStats,
+                        ...{
+                            showStats: cache?.showStats ?? true,
+                            version: statsVersion,
+                        },
+                    };
+                    setStats(newStats);
+                    updateCache(`${appId}`, newStats);
+                    console.log(
+                        `HLTB data updated for ${appId}. Using HLTB game id ${hltbGameStats.gameId}.`
+                    );
                 }
             }
         };
         if (appId) {
-            getData();
+            getData().catch(console.error);
         }
     }, [appId]);
 

--- a/src/patches/LibraryApp.tsx
+++ b/src/patches/LibraryApp.tsx
@@ -9,6 +9,15 @@ import { ReactElement } from 'react';
 import { GameStats } from '../components/GameStats/GameStats';
 import { normalize } from '../utils';
 
+function isSteamGameType(appType: number) {
+    switch (appType) {
+        case 1: // Game
+        case 8: // Demo
+            return true;
+    }
+    return false;
+}
+
 // I hate this method
 export const patchAppPage = () => {
     return routerHook.addPatch('/library/app/:appid', (routerTree: any) => {
@@ -19,6 +28,7 @@ export const patchAppPage = () => {
         if (routeProps) {
             let game: string;
             let appId: number;
+            let isSteamGame: boolean;
 
             const patchHandler = createReactTreePatcher(
                 [
@@ -37,6 +47,7 @@ export const patchAppPage = () => {
                         const overview = children.props.overview;
                         game = normalize(overview.display_name);
                         appId = overview.appid;
+                        isSteamGame = isSteamGameType(overview.app_type);
 
                         return children;
                     },
@@ -76,6 +87,7 @@ export const patchAppPage = () => {
                                 id="hltb-for-deck"
                                 game={game}
                                 appId={appId}
+                                isSteamGame={isSteamGame}
                             />
                         );
                     } else {


### PR DESCRIPTION
Multiple things were changed:
- updated the API to use the appId again for precise matching;
- despagetiffied the `useHltb` as the API changes complicated everything even more;
- game id (for HLTB) will now always be reused unless the cache is cleared;
- removed JSON typing information that is not used, otherwise it's just a clutter that is always outdated;
- added strict JSON verification so that in the future you don't need to guess what's wrong;
- added version number for cached items, so that they can be invalidated by developers when needed.